### PR TITLE
breadcrumbs efficiency fix

### DIFF
--- a/src/ViewByCountry.lua
+++ b/src/ViewByCountry.lua
@@ -107,6 +107,7 @@ local function touchListener(event)
 					counter = 2
 				end
 				audio.play( soundTable["soundSwipe"] )
+				pageBreadCrumb(crumbCount)
 				print(counter)
 				displayFlags()
 			end
@@ -124,13 +125,11 @@ local function touchListener(event)
 					counter = 2
 				end
 				audio.play( soundTable["soundSwipe"] )
+				pageBreadCrumb(crumbCount)
 				print(counter)
 				displayFlags()
 			end
-			
-			pageBreadCrumb(crumbCount)
-			
-		end		
+		end
 	end
 end
 

--- a/src/ViewByCountry.lua
+++ b/src/ViewByCountry.lua
@@ -85,8 +85,8 @@ local function touchListener(event)
 		crumbCount = crumbCount
 
 		if (eventXMove ~= lastValue)then
-			if(eventXMove > 130) then
-				print("Over 130 -- Move LEFT"..eventXMove)
+			if(eventXMove > 100) then
+				print("Over 100 -- Move LEFT"..eventXMove)
 				lastValue = eventXMove
 				
 				if (crumbCount > 1) then
@@ -111,8 +111,8 @@ local function touchListener(event)
 				print(counter)
 				displayFlags()
 			end
-			if(eventXMove < -130 ) then
-				print("Over -130 -- Move RIGHT"..eventXMove)
+			if(eventXMove < -100 ) then
+				print("Over -100 -- Move RIGHT"..eventXMove)
 				lastValue = eventXMove
 				
 				if (crumbCount < 8) then


### PR DESCRIPTION
Previously it was triggering pageBreadCrumb function on any swipe input inside the listener (that was greater than 0), fixed it now so it only runs the function after the legitimate left or right swipe input is registered.