### PR TITLE
minor tweaks to some text elements

### DIFF
--- a/src/ViewByCountry.lua
+++ b/src/ViewByCountry.lua
@@ -289,8 +289,8 @@ function findChars(array,search)
 	--display.remove( crumbGroup ) -- remove crumbs, they are not relevant for search results
 	
 	if(flag ~= 1) then --Search term Not Found.
-		myText = display.newEmbossedText(debugGroup,"No results found.", 200, 180, 240, 300, native.systemFont, 18)
-		myText:setFillColor( 1, 1, 1 )
+		myText = display.newEmbossedText(debugGroup,"No matching countries found.", 200, 184, 240, 300, native.systemFont, 12)
+		myText:setFillColor( 1, 0.8, 0 )
 		debugGroup:insert(myText)
 		sceneGroup:insert(debugGroup)
 		Runtime:addEventListener( "touch", touchListener )

--- a/src/ViewByCountrySearch.lua
+++ b/src/ViewByCountrySearch.lua
@@ -115,8 +115,8 @@ local background = display.newImage(backLayer1, "bg_map_dotted.png", 30, 140)
 
 backLayer1:insert(bg2)
 backLayer1:insert( background )
-rowTitle = display.newEmbossedText(backLayer1, "Results", bg2X, bg2Y - 240,0,0,native.systemFontBold, 28 )
-rowTitle:setFillColor( 0.95, 0.95, 0 ) -- major category
+rowTitle = display.newEmbossedText(backLayer1, "Search Results", bg2X, bg2Y - 224,0,0,native.systemFontBold, 20 )
+rowTitle:setFillColor( 1, 1, 1 ) -- major category
 backLayer1:insert( rowTitle )
 
 sceneGroup1:insert( backLayer1 ) -- One to rule them ALL !

--- a/src/ViewByRanking.lua
+++ b/src/ViewByRanking.lua
@@ -261,7 +261,8 @@ local function textListener( event )
 			else -- Text box is empty
 				counter = 2
 				--displayFlags()
-				searchTitle = display.newEmbossedText( debugGroup,"Please Enter a search term",display.contentCenterX,66, 0, 0, native.systemFont, 14)
+				searchTitle = display.newEmbossedText( debugGroup,"Please enter a country name.",display.contentCenterX,37, 0, 0, native.systemFont, 12)
+				searchTitle:setFillColor( 1, 0.8, 0 )
 				debugGroup:insert(searchTitle)
 		end	
 
@@ -310,7 +311,8 @@ function findChars(array,search)
 	end
 
 	if(#foundArray < 1) then
-		searchTitle = display.newEmbossedText( debugGroup,"No results found.",display.contentCenterX,66, 0, 0, native.systemFont, 14)
+		searchTitle = display.newEmbossedText( debugGroup,"No matching countries found.",display.contentCenterX,37, 0, 0, native.systemFont, 12)
+		searchTitle:setFillColor( 1, 0.8, 0 )
 		debugGroup:insert(searchTitle)
 		return
 	end
@@ -450,9 +452,9 @@ function scene:create( event )
 	bg2.fill = { type="image", filename="bg_blue.jpg" }
 
 	titleString = composer.getVariable("LineString")
-	print(titleString.."LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLL")
-	rowTitle = display.newEmbossedText(backLayer,titleString, display.contentCenterX + 15, display.contentCenterY - 193,270,0,native.systemFontBold, 18 )
-	rowTitle:setFillColor( 0.95, 0.95, 0 ) 
+	--print(titleString.."LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLL")
+	rowTitle = display.newEmbossedText(backLayer,titleString, display.contentCenterX, display.contentCenterY - 186,0,0,native.systemFontBold, 16 )
+	rowTitle:setFillColor( 1, 1, 1 ) 
 	backLayer:insert(rowTitle)
 	
 	


### PR DESCRIPTION
final round of ui polish tweaks:
- search error messages now orange & smaller.
- modified search error messages a bit to allude to country names as suitable input, less generic now.
- went with white/bold for title strings, also adjusted size a tad (on countrysearch + rankings)
- repositioned this above stuff a smidge too.